### PR TITLE
Fix: Missing multisite configuration

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -154,7 +154,7 @@ Config::define( key: 'WP_ALLOW_MULTISITE', value: getenv( name: 'WP_ALLOW_MULTIS
 
 if ( getenv( name: 'MULTISITE' ) === 'true' ) {
 	Config::define( key: 'MULTISITE', value: getenv( name: 'MULTISITE' ) );
-	Config::define( key: 'SUBDOMAIN_INSTALL', value: true );
+	Config::define( key: 'SUBDOMAIN_INSTALL', value: getenv( name: 'SUBDOMAIN_INSTALL' ) );
 	Config::define( key: 'DOMAIN_CURRENT_SITE', value: getenv( name: 'WP_DOMAIN_CURRENT_SITE' ) );
 	Config::define( key: 'PATH_CURRENT_SITE', value: '/' );
 	Config::define( key: 'SITE_ID_CURRENT_SITE', value: 1 );

--- a/config/application.php
+++ b/config/application.php
@@ -154,7 +154,7 @@ Config::define( key: 'WP_ALLOW_MULTISITE', value: getenv( name: 'WP_ALLOW_MULTIS
 
 if ( getenv( name: 'MULTISITE' ) === 'true' ) {
 	Config::define( key: 'MULTISITE', value: getenv( name: 'MULTISITE' ) );
-	Config::define( key: 'SUBDOMAIN_INSTALL', value: getenv( name: 'SUBDOMAIN_INSTALL' ) );
+	Config::define( key: 'SUBDOMAIN_INSTALL', value: getenv( name: 'SUBDOMAIN_INSTALL' ) ?: false );
 	Config::define( key: 'DOMAIN_CURRENT_SITE', value: getenv( name: 'WP_DOMAIN_CURRENT_SITE' ) );
 	Config::define( key: 'PATH_CURRENT_SITE', value: '/' );
 	Config::define( key: 'SITE_ID_CURRENT_SITE', value: 1 );

--- a/example.env
+++ b/example.env
@@ -25,6 +25,8 @@ DISABLE_WP_CRON=false
 # Multisite?
 MULTISITE=false
 # WP_DOMAIN_CURRENT_SITE = 'example.test'
+# Subdomain values: [ Subdomain : true, Subfolder : false ]
+# SUBDOMAIN_INSTALL = false
 
 # Salts
 # Use https://roots.io/salts.html


### PR DESCRIPTION
The constant for `SUBDOMAIN_INSTALL` was previously hard-coded into the file `application.php`, which meant changing the MS structure to sub-folder required a code change. This should ideally be placed in the .env, with the rest of the multisite configs.