### PR TITLE
Fix: Redis and GTM constants

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -176,10 +176,13 @@ Config::define( key: 'S3_UPLOADS_OBJECT_ACL', value: getenv( name: 'S3_UPLOADS_O
 /**
  * Google Tag Manager
  */
-Config::define(
-	key: 'GOOGLE_TAG_MANAGER_CONTAINER_ID',
-	value: getenv( name: 'GOOGLE_TAG_MANAGER_CONTAINER_ID' ) ?: null
-);
+Config::define( key: 'GOOGLE_TAG_MANAGER_CONTAINER_ID', value: getenv( 'GOOGLE_TAG_MANAGER_CONTAINER_ID' ) ?: null );
+
+/**
+ * Redis (Runcloud)
+*/
+Config::define( key: 'RCWP_REDIS_PASSWORD', value: getenv( name: 'RCWP_REDIS_PASSWORD' ) ?: null );
+Config::define( key: 'RCWP_REDIS_DOMAIN', value: getenv( name: 'RCWP_REDIS_DOMAIN' ) ?: null );
 
 Config::apply();
 

--- a/example.env
+++ b/example.env
@@ -22,6 +22,9 @@ WP_DEBUG_DISPLAY=false
 WP_DEBUG_LO#G=../../shared/logs/wp-debug.log
 DISABLE_WP_CRON=false
 
+# Google Tag Manager
+GOOGLE_TAG_MANAGER_CONTAINER_ID = null
+
 # RunCloud - find details in the Runcloud control panel
 RCWP_REDIS_PASSWORD = ""
 RCWP_REDIS_DOMAIN = ''

--- a/example.env
+++ b/example.env
@@ -22,6 +22,10 @@ WP_DEBUG_DISPLAY=false
 WP_DEBUG_LO#G=../../shared/logs/wp-debug.log
 DISABLE_WP_CRON=false
 
+# RunCloud - find details in the Runcloud control panel
+RCWP_REDIS_PASSWORD = ""
+RCWP_REDIS_DOMAIN = ''
+
 # Multisite?
 MULTISITE=false
 # WP_DOMAIN_CURRENT_SITE = 'example.test'


### PR DESCRIPTION
Sites added to Runcloud don't work with Redis, by default. We need to add constants into the `application.php` file to connect to Redis. 

@michaelbragg The code at https://github.com/vatu-team/project-wordpress/blob/fix/gtm-redis-constants/config/application.php#L184 doesn't work, if pulling an array from the .env file. I'm not sure why. If replacing the env variable call with the array directly (see https://github.com/vatu-team/together-trust/blob/main/config/application.php#L184), then it works. Would you mind investigating and fixing, so we can store the array in the env variable instead?