### PR TITLE
Add Google Tag Manager URLs to CSP directives

### DIFF
--- a/public/app/mu-plugins/site-config.php
+++ b/public/app/mu-plugins/site-config.php
@@ -121,6 +121,9 @@ function vatu_content_security_policy_header(): void
 					"'unsafe-eval'",
 					'blob:',
 					'data:',
+					'https://www.googletagmanager.com',
+					'https://tagmanager.google.com',
+					'https://*.googletagmanager.com',
 				]
 			),
 			'style-src'                 => apply_filters(
@@ -130,6 +133,9 @@ function vatu_content_security_policy_header(): void
 					"'unsafe-inline'",
 					'blob:',
 					'data:',
+					'https://googletagmanager.com',
+					'https://tagmanager.google.com',
+					'https://fonts.googleapis.com',
 				]
 			),
 			'img-src'                   => apply_filters(
@@ -137,6 +143,13 @@ function vatu_content_security_policy_header(): void
 				[
 					"'self'",
 					'data:',
+					'www.googletagmanager.com',
+					'https://googletagmanager.com',
+					'https://ssl.gstatic.com',
+					'https://www.gstatic.com',
+					'https://*.google-analytics.com',
+					'https://*.googletagmanager.com',
+					'https://s.w.org',
 				]
 			),
 			'manifest-src'              => apply_filters(
@@ -181,6 +194,11 @@ function vatu_content_security_policy_header(): void
 				'site-config.csp.connect-src',
 				[
 					"'self'",
+					'www.googletagmanager.com',
+					'www.google.com',
+					'https://*.google-analytics.com',
+					'https://*.analytics.google.com',
+					'https://*.googletagmanager.com',
 				]
 			),
 			'frame-ancestors'           => apply_filters(


### PR DESCRIPTION
On almost every project we need to add [Google's domains](https://developers.google.com/tag-platform/security/guides/csp) to our CSP to enable Google Tag Manager, GA4, etc. This PR adds the default domains required for both of those services, so future developers don't have to worry about this, and we don't forget to add the rules manually, resulting in GTM not working.

This is not an exhaustive list, and there are other domains in the docs which may be required for other Google services. 

Google also recommends a more secure way of achieving the same result by using a `nonce`, which should be investigated as a potential longer-term replacement for this proposed PR.