### PR TITLE
Changed: Composer audit to check lockfile over vendor directory

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -54,23 +54,6 @@ jobs:
         run: |
           composer validate --ansi
 
-      - name: 'Get Composer Cache Directory.'
-        id: 'composer-cache'
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: 'Sets up Caching.'
-        uses: 'actions/cache@v5.0.5'
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-composer-build-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-composer-build-
-
-      - name: 'Install dependencies.'
-        run: |
-          composer install --no-interaction --prefer-dist
-
       - name: 'Logs debug information.'
         run: |
           php --version

--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
             "./tools/vendor/bin/parallel-lint --exclude */vendor ./public/app/mu-plugins/site-config.php"
         ],
         "test:security": [
-            "composer audit --ansi"
+            "composer audit --locked --ansi"
         ],
         "test:unit": [
             "./tools/vendor/bin/phpunit -c ./phpunit.dist.xml --testsuite unit"


### PR DESCRIPTION
The aim is to speed up the check as there is no need to run composer install first.