### PR TITLE
Added: WP SEC Adv support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,16 @@
         {
             "name": "wpsecadv",
             "type": "composer",
-            "url": "https://repo-wpsecadv.typist.tech"
+            "url": "https://repo-wpsecadv.typist.tech",
+            "only": [
+                "wp-plugin/*",
+                "wp-theme/*",
+                "wp-core/*",
+                "johnpbloch/wordpress-core",
+                "gravity/*",
+                "yoast/*",
+                "vatu/*"
+            ]
         }
     ],
     "minimum-stability": "stable",
@@ -68,6 +77,20 @@
             "cweagans/composer-patches": true,
             "ergebnis/composer-normalize": true,
             "johnpbloch/wordpress-core-installer": true
+        },
+        "policy": {
+            "abandoned": {
+                "audit": "report"
+            },
+            "advisories": {
+                "ignore-id": {
+                    "CVE-2017-14990": {"reason": "Issue is only present if attacker has comprimised the database."},
+                    "CVE-2022-3590": {"reason": "False positive."}
+                }
+            },
+            "malware": {
+                "block-scope": "all"
+            }
         },
         "optimize-autoloader": true,
         "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,11 @@
             "name": "wp-packages",
             "type": "composer",
             "url": "https://repo.wp-packages.org"
+        },
+        {
+            "name": "wpsecadv",
+            "type": "composer",
+            "url": "https://repo-wpsecadv.typist.tech"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca96f40f297637f0455d5e3abb1fdad4",
+    "content-hash": "504f0aebc2c2134562b67db5e62676cc",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
> [!NOTE]
> Awaiting the release of Compose 2.10 to include the policy schema to ignore known issues in WordPress Core