### PR TITLE
Fixed: rsync negation handling to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,29 @@ jobs:
         run: |
           rsync -azrm --inplace --delete --exclude={'.git','built/'} --exclude-from=.deployignore "${GITHUB_WORKSPACE}/" "${GITHUB_WORKSPACE}/built/"
 
+      # rsync --exclude-from does not honour gitignore-style ! negations.
+      - name: "Rsync negation rules from .deployignore to built directory."
+        run: |
+          grep -E '^!' .deployignore | sed 's/^!//' | while read -r path; do
+            # Skip empty lines and comments
+            [[ -z "$path" || "$path" =~ ^[[:space:]]*# ]] && continue
+            # Remove leading/trailing whitespace
+            path=$(echo "$path" | xargs)
+            # Remove leading slash if present
+            path="${path#/}"
+            # Skip if path is empty after trimming
+            [[ -z "$path" ]] && continue
+            # Copy file or directory if it exists
+            if [[ -e "${GITHUB_WORKSPACE}/${path}" ]]; then
+              # Replace any stale copy left on the --built branch (rsync
+              # --exclude does not delete excluded receivers; plain cp -r
+              # into an existing dir would nest basename/basename).
+              rm -rf "${GITHUB_WORKSPACE}/built/${path}"
+              mkdir -p "${GITHUB_WORKSPACE}/built/$(dirname "$path")"
+              cp -r "${GITHUB_WORKSPACE}/${path}" "${GITHUB_WORKSPACE}/built/${path}"
+            fi
+          done
+
       - name: "Remove `.gitignore` file."
         run: |
           rm ${GITHUB_WORKSPACE}/built/.gitignore


### PR DESCRIPTION
Adds a build step so `.deployignore` `!` allowlist paths are actually copied into `--built`.

`rsync --exclude-from` does not honour gitignore-style negations. Without this step, anything listed as `!/path` is still excluded from the deploy artifact — plugins (and similar) can freeze on `--built` while `vendor/` keeps updating.

Same approach as:

- [medrva](https://github.com/vatu-team/medrva)
- [oxfordshiremind](https://github.com/vatu-team/oxfordshiremind)
- [maelstromeventsolutions](https://github.com/vatu-team/maelstromeventsolutions)
- [satispress](https://github.com/vatu-team/satispress)

## Context

This bit us on SatisPress ([#703](https://github.com/vatu-team/satispress/issues/703)) as production got `psr/log` 3.x with a stale SatisPress 2.0.1 → fatal `Logger::log` signature mismatch. Fixing allowlist paths alone was not enough until this build step landed.

## Test plan

- [ ] Build workflow succeeds
- [ ] `!` paths from `.deployignore` (e.g. `public/app/languages/index.php`) are present on `--built`
