### PR TITLE
Update CSP to include additional sources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "vlucas/phpdotenv": "^5.6.4",
         "wp-plugin/better-passwords": "^1.8.0",
         "wp-plugin/disable-emojis": "^1.9",
-        "wp-plugin/fluent-smtp": "^2.2.95",
+        "wp-plugin/fluent-smtp": "^2.3.0",
         "wp-plugin/safe-svg": "^2.4.0",
         "wp-plugin/two-factor": "^0.16.0",
         "wp-plugin/wordpress-seo": "^28.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "217522d742b3ae27b5182b8e283568f9",
+    "content-hash": "f1f67d7cd2ac9adc4d96ffee30876a52",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1952,15 +1952,15 @@
         },
         {
             "name": "wp-plugin/fluent-smtp",
-            "version": "2.2.95",
+            "version": "2.3.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/fluent-smtp/",
-                "reference": "tags/2.2.95"
+                "reference": "tags/2.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/fluent-smtp.2.2.95.zip"
+                "url": "https://downloads.wordpress.org/plugin/fluent-smtp.2.3.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -1969,17 +1969,17 @@
             "notification-url": "https://wp-packages.org/downloads",
             "authors": [
                 {
-                    "name": "Shahjahan Jewel"
+                    "name": "WPManageNinja"
                 }
             ],
-            "description": "The Ultimate Forever Free Mail SMTP Plugin for WordPress. Connect with any SMTP, SendGrid, Mailgun, Amazon SES, Brevo, Postmark, Sparkpost, Google...",
+            "description": "Free WP Mail SMTP plugin - fix WordPress email deliverability with Gmail, Amazon SES, SendGrid, Mailgun, Cloudflare, Postmark, Brevo and any SMTP.",
             "homepage": "https://fluentsmtp.com",
             "support": {
                 "changelog": "https://wordpress.org/plugins/fluent-smtp/#developers",
                 "issues": "https://wordpress.org/support/plugin/fluent-smtp",
                 "source": "https://plugins.svn.wordpress.org/fluent-smtp"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-08-05T09:25:51+00:00"
         },
         {
             "name": "wp-plugin/safe-svg",

--- a/public/app/mu-plugins/site-config.php
+++ b/public/app/mu-plugins/site-config.php
@@ -120,10 +120,17 @@ function vatu_content_security_policy_header(): void
 					"'unsafe-eval'",
 					'blob:',
 					'data:',
+					'https://*.googletagmanager.com',
 					'https://www.googletagmanager.com',
 					'https://tagmanager.google.com',
-					'https://*.googletagmanager.com',
+					'https://*.cloudflareinsights.com',
+					'https://static.cloudflareinsights.com',
+					'https://cdn-cookieyes.com',
 					'https://challenges.cloudflare.com',
+					'https://www.google.com/recaptcha/',
+					'https://www.gstatic.com/recaptcha/',
+					'https://connect.facebook.net/',
+					'https://snap.licdn.com',
 				]
 			),
 			'style-src'                 => apply_filters(
@@ -135,6 +142,10 @@ function vatu_content_security_policy_header(): void
 					'data:',
 					'https://googletagmanager.com',
 					'https://tagmanager.google.com',
+					'https://fonts.googleapis.com',
+					'https://use.typekit.net',
+					'https://p.typekit.net',
+					'https://maxcdn.bootstrapcdn.com',
 				]
 			),
 			'img-src'                   => apply_filters(
@@ -143,6 +154,8 @@ function vatu_content_security_policy_header(): void
 					"'self'",
 					'data:',
 					'https://patterns.olliewp.com',
+					'https://cdn.XXXXXXXXXXXX.com',
+					'https://XXXXXXXXXXXX.cloudfront.net',
 					'https://secure.gravatar.com',
 					'www.googletagmanager.com',
 					'https://googletagmanager.com',
@@ -150,6 +163,14 @@ function vatu_content_security_policy_header(): void
 					'https://www.gstatic.com',
 					'https://*.google-analytics.com',
 					'https://*.googletagmanager.com',
+					'https://s.w.org',
+					'https://i.ytimg.com',
+					'https://*.ytimg.com',
+					'https://*.tumblr.com',
+					'https://cdn-cookieyes.com',
+					'https://*.linkedin.com',
+					'https://*.facebook.com',
+					'https://*.googlesyndication.com',
 				]
 			),
 			'manifest-src'              => apply_filters(
@@ -189,6 +210,12 @@ function vatu_content_security_policy_header(): void
 				[
 					"'self'",
 					'https://challenges.cloudflare.com',
+					'https://www.google.com/recaptcha/',
+					'https://www.google.com/maps/',
+					'https://recaptcha.google.com/recaptcha/',
+					'https://www.youtube.com',
+					'https://youtube.com',
+					'https://www.youtube-nocookie.com',
 				]
 			),
 			'connect-src'               => apply_filters(
@@ -201,6 +228,12 @@ function vatu_content_security_policy_header(): void
 					'https://*.google-analytics.com',
 					'https://*.analytics.google.com',
 					'https://*.googletagmanager.com',
+					'https://www.google.com/recaptcha/',
+					'https://*.cookieyes.com',
+					'cdn-cookieyes.com',
+					'https://px.ads.linkedin.com',
+					'https://*.contentsquare.net',
+					'https://*.googlesyndication.com',
 				]
 			),
 			'frame-ancestors'           => apply_filters(


### PR DESCRIPTION
Added new sources for Content Security Policy including Cloudflare, Google Tag Manager, and Typekit.